### PR TITLE
Add Telegram React Web App example

### DIFF
--- a/telegram-react/app.jsx
+++ b/telegram-react/app.jsx
@@ -1,0 +1,35 @@
+const { useState, useEffect } = React;
+
+function App() {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const tg = window.Telegram.WebApp;
+    if (tg) {
+      tg.ready();
+      if (tg.initDataUnsafe && tg.initDataUnsafe.user) {
+        setUser(tg.initDataUnsafe.user);
+      }
+    }
+  }, []);
+
+  if (!user) {
+    return (
+      <div className="container">
+        <h2>Верификация Telegram</h2>
+        <p>Пожалуйста, откройте приложение внутри Telegram для прохождения верификации.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container">
+      <h2>Привет, {user.first_name}!</h2>
+      {user.username && <p>@{user.username}</p>}
+      <p>ID: {user.id}</p>
+      <p>initData: {window.Telegram.WebApp.initData}</p>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/telegram-react/index.html
+++ b/telegram-react/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Telegram React Web App</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.jsx"></script>
+</body>
+</html>

--- a/telegram-react/style.css
+++ b/telegram-react/style.css
@@ -1,0 +1,12 @@
+body {
+  background: #0E0E0E;
+  color: #fff;
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+}
+
+.container {
+  max-width: 480px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- add a new React-based Telegram Web App example
- show Telegram user information when launched inside Telegram

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f4b77fedc8322bc346014d80fb7e1